### PR TITLE
Added a static variable to store the cached config

### DIFF
--- a/src/Listener/ConfigListener.php
+++ b/src/Listener/ConfigListener.php
@@ -56,6 +56,11 @@ class ConfigListener extends AbstractListener implements
      * @var array
      */
     protected $paths = [];
+        
+    /**
+     * @var array
+     */
+    protected static $cachedConfig;
 
     /**
      * __construct
@@ -388,6 +393,10 @@ class ConfigListener extends AbstractListener implements
      */
     protected function getCachedConfig()
     {
-        return include $this->getOptions()->getConfigCacheFile();
+        if (!self::$cachedConfig) {
+            self::$cachedConfig = include $this->getOptions()->getConfigCacheFile();
+        }
+        
+        return self::$cachedConfig;
     }
 }


### PR DESCRIPTION
Added a static variable to store the cached config. This prevents additional calls from calling an include of the cached file and consuming additional memory. Since the cached config can be quite large, additional calls in a long running process can result in excessive memory consumption. Using qcachegrind and some php profiling this was found while profiling our codeception testing suite.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug? yes
  - [ ] Detail how the bug is invoked currently.
![image](https://user-images.githubusercontent.com/722417/69482224-1685f500-0dde-11ea-9ca0-42fb2b6fa533.png)

  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
